### PR TITLE
Postgres bool issue

### DIFF
--- a/aggregate_if.py
+++ b/aggregate_if.py
@@ -42,14 +42,14 @@ class SqlAggregate(DjangoSqlAggregate):
         Return sql for condition.
         '''
         def escape(value):
+            if isinstance(value, bool):
+                value = str(int(value))
             if isinstance(value, basestring):
                 # Escape params used with LIKE
                 if '%' in value:
                     value = value.replace('%', '%%')
                 # Add single quote to text values
                 value = "'" + value + "'"
-            if isinstance(value, bool):
-                value = int(value)
             return value
 
         sql, param = self.condition.query.where.as_sql(qn, connection)

--- a/tests/aggregation/fixtures/aggregation.json
+++ b/tests/aggregation/fixtures/aggregation.json
@@ -156,7 +156,8 @@
             "books": [3, 4, 6],
             "name": "Mamma and Pappa's Books",
             "original_opening": "1945-4-25 16:24:14",
-            "friday_night_closing": "21:30:00"
+            "friday_night_closing": "21:30:00",
+            "has_coffee": true
         }
     },
     {

--- a/tests/aggregation/models.py
+++ b/tests/aggregation/models.py
@@ -36,6 +36,7 @@ class Store(models.Model):
     books = models.ManyToManyField(Book)
     original_opening = models.DateTimeField()
     friday_night_closing = models.TimeField()
+    has_coffee = models.BooleanField()
 
     def __unicode__(self):
         return self.name

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -42,6 +42,11 @@ class BaseAggregateTestCase(TestCase):
         # If there are no matching aggregates, then None, not 0 is the answer.
         self.assertEqual(vals["age__sum"], None)
 
+    def test_condition_with_bool_value(self):
+        vals = Store.objects.all().aggregate(with_coffee=Count("books", only=Q(has_coffee=True)))
+        self.assertEqual(len(vals), 1)
+        self.assertEqual(vals["with_coffee"], 3)
+
     def test_related_aggregate(self):
         vals = Author.objects.aggregate(Avg("friends__age"))
         self.assertEqual(len(vals), 1)


### PR DESCRIPTION
It was reported in freedomsponsors repository (https://github.com/freedomsponsors/www.freedomsponsors.org/pull/120). Postgres does not support bool/int comparison without explicit cast.

This pull request solve the issue. I didn't tested it with MySQL, but Travis will do it.
