### PR TITLE
Avoid SQL injection

### DIFF
--- a/aggregate_if.py
+++ b/aggregate_if.py
@@ -46,6 +46,9 @@ class SqlAggregate(DjangoSqlAggregate):
                 # Escape params used with LIKE
                 if '%' in value:
                     value = value.replace('%', '%%')
+                # Escape single quotes
+                if "'" in value:
+                    value = value.replace("'", "''")
                 # Add single quote to text values
                 value = "'" + value + "'"
             if isinstance(value, bool):

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -17,6 +17,10 @@ class BaseAggregateTestCase(TestCase):
     def test_empty_aggregate(self):
         self.assertEqual(Author.objects.all().aggregate(), {})
 
+    def test_quote_escape(self):
+        vals = Author.objects.all().aggregate(Count("id", only=Q(name="nobody'")))
+        self.assertEqual(vals['id__count'], 0)
+
     def test_single_aggregate(self):
         vals = Author.objects.aggregate(Avg("age"))
         self.assertEqual(vals, {"age__avg": Approximate(37.4, places=1)})


### PR DESCRIPTION
I didn't try harder to found a useful example to inject, but I'm sure it is possible to exploit it with a crafted parameter, so you should always escape single quotes.
