### PR TITLE
Adds support for alias relabeling permitting excludes and updates for aggregates filtered on remote foreign key relations

### DIFF
--- a/aggregate_if.py
+++ b/aggregate_if.py
@@ -23,7 +23,10 @@ class SqlAggregate(DjangoSqlAggregate):
     def relabel_aliases(self, change_map):
         super(SqlAggregate, self).relabel_aliases(change_map)
         if self.has_condition:
-            self.condition.relabel_aliases(change_map)
+            condition_change_map = dict((k, v) for k, v in \
+                change_map.iteritems() if k in self.condition.query.alias_map
+            )
+            self.condition.query.change_aliases(condition_change_map)
 
     def as_sql(self, qn, connection):
         if self.has_condition:


### PR DESCRIPTION
Apart from correcting the relabeling of aliases, I've corrected the test for it and added a new one to make a difference between aggregates filtering on m2m relations and ones filtering on remote foreign key relations.

Check it out and give me your thoughts on it.

Thanks for a life-saving extension to the ORM!

Hampus
