### PR TITLE
Allow only clause to refer to fields not already joined to

### DIFF
--- a/aggregate_if.py
+++ b/aggregate_if.py
@@ -115,7 +115,12 @@ class Aggregate(DjangoAggregate):
                 if field_list[-1] in query.query_terms:
                     field_list.pop()
                 _, _, _, join_list, _, _ = query.setup_joins(field_list, query.model._meta, query.get_initial_alias(), False)
-                query.promote_joins(join_list, True)
+                # Django 1.5+
+                if hasattr(query, 'promote_joins'):
+                    query.promote_joins(join_list, True)
+                # Django < 1.5
+                elif hasattr(query, 'promote_alias_chain'):
+                    query.promote_alias_chain(join_list, True)
 
         aggregate = self.sql_klass(col, source=source, is_summary=is_summary, condition=self.condition, **self.extra)
         query.aggregates[alias] = aggregate

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -652,7 +652,7 @@ class BaseAggregateTestCase(TestCase):
         )
 
     def test_only_requires_extra_join(self):
-        publishers = Publisher.objects.annotate(jeff_books=Count('book', only=Q(book__contact__name__icontains='Jeff')))
+        publishers = Publisher.objects.annotate(jeff_books=Count('book', only=Q(book__contact__name__icontains='Jeff'))).order_by('id')
         self.assertQuerysetEqual(
             publishers, [
                 ('Apress', 0),

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -663,3 +663,18 @@ class BaseAggregateTestCase(TestCase):
             ],
             lambda b: (b.name, b.jeff_books),
         )
+
+        # Test with compound Q object
+        # Get publishers annotated with a count of books that are in stores with coffee or named Books.com
+        q = Q(book__store__has_coffee=True) | Q(book__store__name__icontains="Books.com")
+        publishers = Publisher.objects.annotate(coffee_books=Count('book', distinct=True, only=q))
+        self.assertQuerysetEqual(
+            publishers, [
+                ('Apress', 2),
+                ('Sams', 0),
+                ('Prentice Hall', 2),
+                ('Morgan Kaufmann', 1),
+                ('Jonno\'s House of Books', 0)
+            ],
+            lambda b: (b.name, b.coffee_books),
+        )

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -650,3 +650,16 @@ class BaseAggregateTestCase(TestCase):
                 (Decimal('82.8'), 1),
             ]
         )
+
+    def test_only_requires_extra_join(self):
+        publishers = Publisher.objects.annotate(jeff_books=Count('book', only=Q(book__contact__name__icontains='Jeff')))
+        self.assertQuerysetEqual(
+            publishers, [
+                ('Apress', 0),
+                ('Sams', 0),
+                ('Prentice Hall', 1),
+                ('Morgan Kaufmann', 0),
+                ('Jonno\'s House of Books', 0)
+            ],
+            lambda b: (b.name, b.jeff_books),
+        )


### PR DESCRIPTION
It should be possible to do a query like this:

```
publishers = Publisher.objects.annotate(jeff_books=Count('book', only=Q(book__contact__name__icontains='Jeff')))
```

This generates an error because the author table is not joined to. In this pull request, the `only` clause explicitly generates the necessary joins so that the above query will work.

Test included.
