### PR TITLE
Fix for Django 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .tox
 tmp/
 dist/
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 services:
   - mysql
   - postgresql
@@ -14,12 +15,20 @@ env:
   - DJANGO=1.6 DB=sqlite
   - DJANGO=1.6 DB=mysql
   - DJANGO=1.6 DB=postgres
-#matrix:
-#  include:
-#    - python: 3.3
-#      env: DJANGO=1.6 DB=sqlite
-#    - python: 3.3
-#      env: DJANGO=1.6 DB=postgres
+  - DJANGO=1.7 DB=sqlite
+  - DJANGO=1.7 DB=mysql
+  - DJANGO=1.7 DB=postgres
+
+matrix:
+  include:
+    - python: 3.4
+      env: DJANGO=1.6 DB=sqlite
+    - python: 3.4
+      env: DJANGO=1.6 DB=postgres
+    - python: 3.4
+      env: DJANGO=1.7 DB=sqlite
+    - python: 3.4
+      env: DJANGO=1.7 DB=postgres
 
 before_script:
   - mysql -e 'create database aggregation;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,21 @@ env:
 matrix:
   exclude:
     - python: 3.4
-      env: DJANGO=1.4
+      env: DJANGO=1.4 DB=sqlite
     - python: 3.4
-      env: DJANGO=1.5
+      env: DJANGO=1.4 DB=mysql
     - python: 3.4
-      env: DB=mysql
+      env: DJANGO=1.4 DB=postgres
+    - python: 3.4
+      env: DJANGO=1.5 DB=sqlite
+    - python: 3.4
+      env: DJANGO=1.5 DB=mysql
+    - python: 3.4
+      env: DJANGO=1.5 DB=postgres
+    - python: 3.4
+      env: DJANGO=1.6 DB=mysql
+    - python: 3.4
+      env: DJANGO=1.7 DB=mysql
 
 before_script:
   - mysql -e 'create database aggregation;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,21 +21,21 @@ env:
 
 matrix:
   exclude:
-    - python: 3.4
+    - python: "3.4"
       env: DJANGO=1.4 DB=sqlite
-    - python: 3.4
+    - python: "3.4"
       env: DJANGO=1.4 DB=mysql
-    - python: 3.4
+    - python: "3.4"
       env: DJANGO=1.4 DB=postgres
-    - python: 3.4
+    - python: "3.4"
       env: DJANGO=1.5 DB=sqlite
-    - python: 3.4
+    - python: "3.4"
       env: DJANGO=1.5 DB=mysql
-    - python: 3.4
+    - python: "3.4"
       env: DJANGO=1.5 DB=postgres
-    - python: 3.4
+    - python: "3.4"
       env: DJANGO=1.6 DB=mysql
-    - python: 3.4
+    - python: "3.4"
       env: DJANGO=1.7 DB=mysql
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,13 @@ env:
   - DJANGO=1.7 DB=postgres
 
 matrix:
-  include:
+  exclude:
     - python: 3.4
-      env: DJANGO=1.6 DB=sqlite
+      env: DJANGO=1.4
     - python: 3.4
-      env: DJANGO=1.6 DB=postgres
+      env: DJANGO=1.5
     - python: 3.4
-      env: DJANGO=1.7 DB=sqlite
-    - python: 3.4
-      env: DJANGO=1.7 DB=postgres
+      env: DB=mysql
 
 before_script:
   - mysql -e 'create database aggregation;'

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,10 @@ Contributors
 Changelog
 ---------
 
+0.5
+
+    - Support for Django 1.7
+
 0.4
     - Use tox to run tests.
     - Add support for Django 1.6.

--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,11 @@ Contributors
 * `Iuri de Silvio <https://github.com/iurisilvio>`_
 * `Hampus Stjernhav <https://github.com/champ>`_
 * `Bradley Martsberger <https://github.com/martsberger>`_
+* `Markus Bertheau <https://github.com/mbertheau>`_
+* `end0 <https://github.com/end0>`_
+* `Scott Sexton <https://github.com/scottsexton>`_
+* `Mauler <https://github.com/mauler>`_
+* `trbs <https://github.com/trbs>`_
 
 Changelog
 ---------

--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,6 @@ Changelog
 ---------
 
 0.5
-
     - Support for Django 1.7
 
 0.4

--- a/aggregate_if.py
+++ b/aggregate_if.py
@@ -27,12 +27,17 @@ class SqlAggregate(DjangoSqlAggregate):
         self.condition = condition
 
     def relabel_aliases(self, change_map):
-        super(SqlAggregate, self).relabel_aliases(change_map)
+        if VERSION < (1, 7):
+            super(SqlAggregate, self).relabel_aliases(change_map)
         if self.has_condition:
             condition_change_map = dict((k, v) for k, v in \
                 change_map.iteritems() if k in self.condition.query.alias_map
             )
             self.condition.query.change_aliases(condition_change_map)
+
+    def relabeled_clone(self, change_map):
+        self.relabel_aliases(change_map)
+        return super(SqlAggregate, self).relabeled_clone(change_map)
 
     def as_sql(self, qn, connection):
         if self.has_condition:

--- a/aggregate_if.py
+++ b/aggregate_if.py
@@ -31,7 +31,7 @@ class SqlAggregate(DjangoSqlAggregate):
             super(SqlAggregate, self).relabel_aliases(change_map)
         if self.has_condition:
             condition_change_map = dict((k, v) for k, v in \
-                change_map.iteritems() if k in self.condition.query.alias_map
+                change_map.items() if k in self.condition.query.alias_map
             )
             self.condition.query.change_aliases(condition_change_map)
 

--- a/runtests.py
+++ b/runtests.py
@@ -27,8 +27,12 @@ def get_runner(settings_module):
     '''
     os.environ['DJANGO_SETTINGS_MODULE'] = settings_module
 
+    import django
     from django.test.utils import get_runner
     from django.conf import settings
+
+    if hasattr(django, 'setup'):
+        django.setup()
 
     return get_runner(settings)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 
 setup(name='django-aggregate-if',
-      version='0.4',
+      version='0.5',
       description='Conditional aggregates for Django, just like the famous SumIf in Excel.',
       long_description=open(os.path.join(os.path.dirname(__file__), "README.rst")).read(),
       author="Henrique Bastos", author_email="henrique@bastos.net",

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -524,7 +524,7 @@ class BaseAggregateTestCase(TestCase):
         vals = Author.objects.filter(pk=1).aggregate(Count("friends__id"))
         self.assertEqual(vals, {"friends__id__count": 2})
 
-        books = Book.objects.annotate(num_authors=Count("authors__name")).filter(num_authors__ge=2).order_by("pk")
+        books = Book.objects.annotate(num_authors=Count("authors__name")).filter(num_authors=2).order_by("pk")
         self.assertQuerysetEqual(
             books, [
                 "The Definitive Guide to Django: Web Development Done Right",

--- a/tests/aggregation/tests.py
+++ b/tests/aggregation/tests.py
@@ -4,7 +4,15 @@ import datetime
 from decimal import Decimal
 
 from django.db.models import Q, F
-from django.test import TestCase, Approximate
+from django.test import TestCase
+
+try:
+    # Django < 1.7
+    from django.test import Approximate
+except ImportError as e:
+    # Django >= 1.7
+    from django.test.utils import Approximate
+
 
 from aggregate_if import Sum, Count, Avg, Max, Min
 

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -14,3 +14,8 @@ INSTALLED_APPS = (
 SITE_ID=1,
 
 SECRET_KEY='secret'
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+)

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -14,3 +14,8 @@ INSTALLED_APPS = (
 SITE_ID=1,
 
 SECRET_KEY='secret'
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+)

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -14,3 +14,8 @@ INSTALLED_APPS = (
 SITE_ID=1,
 
 SECRET_KEY='secret'
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+)

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,10 @@ envlist =
     py27-django1.6-postgres,
     py27-django1.6-mysql,
 
+    py27-django1.7-sqlite,
+    py27-django1.7-postgres,
+    py27-django1.7-mysql,
+
     py34-django1.6-sqlite,
     py34-django1.6-postgres,
     #py34-django1.6-mysql

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,9 @@ envlist =
     py34-django1.6-postgres,
     #py34-django1.6-mysql
 
+    py34-django1.7-sqlite,
+    py34-django1.7-postgres,
+    #py34-django1.7-mysql
 
 [testenv]
 whitelist_externals=
@@ -36,9 +39,9 @@ deps =
     django==1.4
     psycopg2
 commands =
-    psql -c 'create database aggregation;'
+    psql -c 'create database aggregation;' postgres
     python runtests.py --settings tests.test_postgres
-    psql -c 'drop database aggregation;'
+    psql -c 'drop database aggregation;' postgres
 
 [testenv:py27-django1.4-mysql]
 basepython = python2.7
@@ -63,9 +66,9 @@ deps =
     django==1.5
     psycopg2
 commands =
-    psql -c 'create database aggregation;'
+    psql -c 'create database aggregation;' postgres
     python runtests.py --settings tests.test_postgres
-    psql -c 'drop database aggregation;'
+    psql -c 'drop database aggregation;' postgres
 
 [testenv:py27-django1.5-mysql]
 basepython = python2.7
@@ -90,14 +93,42 @@ deps =
     django==1.6
     psycopg2
 commands =
-    psql -c 'create database aggregation;'
+    psql -c 'create database aggregation;' postgres
     python runtests.py --settings tests.test_postgres
-    psql -c 'drop database aggregation;'
+    psql -c 'drop database aggregation;' postgres
 
 [testenv:py27-django1.6-mysql]
 basepython = python2.7
 deps =
     django==1.6
+    mysql-python
+commands =
+    mysql -e 'create database aggregation;'
+    python runtests.py --settings tests.test_mysql
+    mysql -e 'drop database aggregation;'
+
+
+# Python 2.7 and Django 1.7
+[testenv:py27-django1.7-sqlite]
+basepython = python2.7
+deps =
+    django==1.7
+commands = python runtests.py --settings tests.test_sqlite
+
+[testenv:py27-django1.7-postgres]
+basepython = python2.7
+deps =
+    django==1.7
+    psycopg2
+commands =
+    psql -c 'create database aggregation;' postgres
+    python runtests.py --settings tests.test_postgres
+    psql -c 'drop database aggregation;' postgres
+
+[testenv:py27-django1.7-mysql]
+basepython = python2.7
+deps =
+    django==1.7
     mysql-python
 commands =
     mysql -e 'create database aggregation;'
@@ -119,14 +150,43 @@ deps =
     django==1.6
     psycopg2
 commands =
-    psql -c 'create database aggregation;'
+    psql -c 'create database aggregation;' postgres
     python runtests.py --settings tests.test_postgres
-    psql -c 'drop database aggregation;'
+    psql -c 'drop database aggregation;' postgres
 
 [testenv:py34-django1.6-mysql]
 basepython = python3.4
 deps =
     django==1.6
+    mysql-python3
+commands =
+    mysql -e 'create database aggregation;'
+    python runtests.py --settings tests.test_mysql
+    mysql -e 'drop database aggregation;'
+
+
+# Python 3.4
+# Django 1.7
+[testenv:py34-django1.7-sqlite]
+basepython = python3.4
+deps =
+    django==1.7
+commands = python runtests.py --settings tests.test_sqlite
+
+[testenv:py34-django1.7-postgres]
+basepython = python3.4
+deps =
+    django==1.7
+    psycopg2
+commands =
+    psql -c 'create database aggregation;' postgres
+    python runtests.py --settings tests.test_postgres
+    psql -c 'drop database aggregation;' postgres
+
+[testenv:py34-django1.7-mysql]
+basepython = python3.4
+deps =
+    django==1.7
     mysql-python3
 commands =
     mysql -e 'create database aggregation;'


### PR DESCRIPTION
@trbs, @end0, @owais, @kawa-marcin, 

I've applied the suggested patches to fix the call to `promote_joins` in Django 1.7.

I've also updated travis and tox scripts to include Django's new version.

However due to Django's new AppConfig boot sequence, the tests are not running on Django 1.7.

``` pytb
py34-django1.7-postgres runtests: commands[1] | python runtests.py --settings tests.test_postgres
Creating test database for alias 'default'...
Traceback (most recent call last):
  File "runtests.py", line 44, in <module>
    runtests()
  File "runtests.py", line 40, in runtests
    sys.exit(runner.run_tests([]))
  File "/Users/henrique/workspace/django-aggregate-if/.tox/py34-django1.7-postgres/lib/python3.4/site-packages/django/test/runner.py", line 147, in run_tests
    old_config = self.setup_databases()
  File "/Users/henrique/workspace/django-aggregate-if/.tox/py34-django1.7-postgres/lib/python3.4/site-packages/django/test/runner.py", line 109, in setup_databases
    return setup_databases(self.verbosity, self.interactive, **kwargs)
  File "/Users/henrique/workspace/django-aggregate-if/.tox/py34-django1.7-postgres/lib/python3.4/site-packages/django/test/runner.py", line 299, in setup_databases
    serialize=connection.settings_dict.get("TEST_SERIALIZE", True),
  File "/Users/henrique/workspace/django-aggregate-if/.tox/py34-django1.7-postgres/lib/python3.4/site-packages/django/db/backends/creation.py", line 374, in create_test_db
    test_flush=True,
  File "/Users/henrique/workspace/django-aggregate-if/.tox/py34-django1.7-postgres/lib/python3.4/site-packages/django/core/management/__init__.py", line 93, in call_command
    app_name = get_commands()[name]
  File "/Users/henrique/workspace/django-aggregate-if/.tox/py34-django1.7-postgres/lib/python3.4/functools.py", line 428, in wrapper
    result = user_function(*args, **kwds)
  File "/Users/henrique/workspace/django-aggregate-if/.tox/py34-django1.7-postgres/lib/python3.4/site-packages/django/core/management/__init__.py", line 73, in get_commands
    for app_config in reversed(list(apps.get_app_configs())):
  File "/Users/henrique/workspace/django-aggregate-if/.tox/py34-django1.7-postgres/lib/python3.4/site-packages/django/apps/registry.py", line 137, in get_app_configs
    self.check_apps_ready()
  File "/Users/henrique/workspace/django-aggregate-if/.tox/py34-django1.7-postgres/lib/python3.4/site-packages/django/apps/registry.py", line 124, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.
```

I need to make all tests passing before releasing `0.5`. I plan to figure this out during the next week. Any help is very welcome.
