### PR TITLE
Test was failing due to table alias not being applied. 

### DIFF
--- a/aggregate_if.py
+++ b/aggregate_if.py
@@ -27,12 +27,17 @@ class SqlAggregate(DjangoSqlAggregate):
         self.condition = condition
 
     def relabel_aliases(self, change_map):
-        super(SqlAggregate, self).relabel_aliases(change_map)
+        if VERSION < (1, 7):
+            super(SqlAggregate, self).relabel_aliases(change_map)
         if self.has_condition:
             condition_change_map = dict((k, v) for k, v in \
                 change_map.iteritems() if k in self.condition.query.alias_map
             )
             self.condition.query.change_aliases(condition_change_map)
+
+    def relabeled_clone(self, change_map):
+        self.relabel_aliases(change_map)
+        return super(SqlAggregate, self).relabeled_clone(change_map)
 
     def as_sql(self, qn, connection):
         if self.has_condition:


### PR DESCRIPTION
TLDR; In Django 1.7 we need to to call change_aliases for our SqlAggregate conditional_template.

The query in test_relabel_aliases looks like this in Django 1.6.8 (passing):

```
SELECT `aggregation_book`.`id`, `aggregation_book`.`isbn`, `aggregation_book`.`name`, 
`aggregation_book`.`pages`, `aggregation_book`.`rating`, `aggregation_book`.`price`, 
`aggregation_book`.`contact_id`, `aggregation_book`.`publisher_id`, `aggregation_book`.`pubdate`, 
AVG(T5.`age`) AS `mean_age` FROM `aggregation_book` LEFT OUTER JOIN 
`aggregation_book_authors` ON ( `aggregation_book`.`id` = `aggregation_book_authors`.`book_id` ) 
LEFT OUTER JOIN `aggregation_author` T5 ON ( `aggregation_book_authors`.`author_id` = T5.`id` ) 
WHERE NOT (`aggregation_book`.`id` IN (SELECT U1.`book_id` FROM `aggregation_book_authors` U1 
WHERE (U1.`author_id`) IN (SELECT `aggregation_author`.`id` FROM `aggregation_author` LEFT 
OUTER JOIN `aggregation_book_authors` ON ( `aggregation_author`.`id` = 
`aggregation_book_authors`.`author_id` ) LEFT OUTER JOIN `aggregation_book` ON ( 
`aggregation_book_authors`.`book_id` = `aggregation_book`.`id` ) GROUP BY `aggregation_author`.`id`, 
`aggregation_author`.`name`, `aggregation_author`.`age` HAVING MIN(CASE WHEN 
`aggregation_author`.`id` >= 1  THEN `aggregation_book`.`rating` ELSE null END) < 0.0  ORDER BY 
NULL))) GROUP BY `aggregation_book`.`id` ORDER BY NULL
```

But in Django 1.7 (failing) it looks like this:

```
SELECT `aggregation_book`.`id`, `aggregation_book`.`isbn`, `aggregation_book`.`name`,
`aggregation_book`.`pages`, `aggregation_book`.`rating`, `aggregation_book`.`price`, 
`aggregation_book`.`contact_id`, `aggregation_book`.`publisher_id`, `aggregation_book`.`pubdate`, 
AVG(T5.`age`) AS `mean_age` FROM `aggregation_book` LEFT OUTER JOIN 
`aggregation_book_authors` ON ( `aggregation_book`.`id` = `aggregation_book_authors`.`book_id` ) 
LEFT OUTER JOIN `aggregation_author` T5 ON ( `aggregation_book_authors`.`author_id` = T5.`id` ) 
WHERE NOT (`aggregation_book`.`id` IN (SELECT V1.`book_id` AS `book_id` FROM 
`aggregation_book_authors` V1 WHERE (V1.`author_id`) IN (SELECT U0.`id` FROM 
`aggregation_author` U0 LEFT OUTER JOIN `aggregation_book_authors` U1 ON ( U0.`id` = 
U1.`author_id` ) LEFT OUTER JOIN `aggregation_book` U2 ON ( U1.`book_id` = U2.`id` ) GROUP BY 
U0.`id`, U0.`name`, U0.`age` HAVING MIN(CASE WHEN `aggregation_author`.`id` >= 1 THEN 
U2.`rating` ELSE null END) < 0.0 ORDER BY NULL))) GROUP BY `aggregation_book`.`id` ORDER BY 
NULL
```

The table alias for aggregation_author is not being properly applied. The Django 1.7 query is using 
`WHEN aggregation_author.id >= 1 THEN U2.rating` when instead it needs to apply the alias and say 
`WHEN U0.id >= 1 THEN U2.rating`
